### PR TITLE
Brown -> Braun

### DIFF
--- a/src/AddMulSgn.sv
+++ b/src/AddMulSgn.sv
@@ -10,7 +10,7 @@
 // Copyright (c) 1998 Integrated Systems Laboratory, ETH Zurich
 ////////////////////////////////////////////////////////////////////////////////
 // Description :
-// Adder-multiplier for signed numbers (Brown). First adds two numbers, then
+// Adder-multiplier for signed numbers (Braun). First adds two numbers, then
 // multiplies the result with the multiplicand. Can be used for multiplication
 // with an input operand in carry-save number format. Result is only valid if
 // sum does not overflow.

--- a/src/AddMulUns.sv
+++ b/src/AddMulUns.sv
@@ -12,7 +12,7 @@
 // - Paul Scheffler <paulsc@iis.ee.ethz.ch>
 //
 // Description :
-// Adder-multiplier for unsigned numbers (Brown). First adds two numbers, then
+// Adder-multiplier for unsigned numbers (Braun). First adds two numbers, then
 // multiplies the result with the multiplicand. Can be used for multiplication
 // with an input operand in carry-save number format. Result is only valid if
 // sum does not overflow.

--- a/src/MulAddUns.sv
+++ b/src/MulAddUns.sv
@@ -12,7 +12,7 @@
 // - Paul Scheffler <paulsc@iis.ee.ethz.ch>
 //
 // Description :
-// Multiplier-adder for unsigned numbers (Brown). First multiplies two numbers,
+// Multiplier-adder for unsigned numbers (Braun). First multiplies two numbers,
 // then adds an additional operand to the result.
 // P = (X*Y) +A
 

--- a/src/MulCsvSgn.sv
+++ b/src/MulCsvSgn.sv
@@ -13,7 +13,7 @@
 //
 // Description :
 // Multiplier for signed numbers with one input operand and the
-// result in carry-save number representation (Brown). First adds two
+// result in carry-save number representation (Braun). First adds two
 // numbers, then multiplies the result with the multiplicand without
 // performing final addition. Result is only valid if sum of
 // carry-save input operands does not overflow.

--- a/src/MulCsvUns.sv
+++ b/src/MulCsvUns.sv
@@ -13,7 +13,7 @@
 //
 // Description :
 // Multiplier for unsigned numbers with one input operand and the
-// result in carry-save number representation (Brown). First adds two
+// result in carry-save number representation (Braun). First adds two
 // numbers, then multiplies the result with the multiplicand without
 // performing final addition. Result is only valid if sum of
 // carry-save input operands does not overflow.

--- a/src/MulUns.sv
+++ b/src/MulUns.sv
@@ -12,7 +12,7 @@
 // - Paul Scheffler <paulsc@iis.ee.ethz.ch>
 //
 // Description :
-// Multiplier for unsigned numbers (Brown) using carry-save adder and
+// Multiplier for unsigned numbers (Braun) using carry-save adder and
 // final adder.
 // P = X*Y
 


### PR DESCRIPTION
The Braun multiplier is named after Edward L. Braun supposedly due to his 1963 book Digital Computer Design: Logic, Circuitry, and Synthesis. This PR fixes the "Brown" spelling to "Braun". This misspelling was carried over from [the original 1998 VHDL LAU](https://iis-people.ee.ethz.ch/~zimmi/arith_lib.html#library)